### PR TITLE
update dev tooling from adc-streaming

### DIFF
--- a/hop-{{cookiecutter.app_name}}-app/Makefile
+++ b/hop-{{cookiecutter.app_name}}-app/Makefile
@@ -5,12 +5,12 @@ help :
 	@echo
 	@echo '  make test                  run unit tests'
 	@echo '  make lint                  run linter'
-	@echo '  make format                run code formatter, giving a diff for recommended changes'
+	@echo '  make format                run code formatter'
 	@echo '  make doc                   make documentation'
 	@echo '  make changelog             update changelog based on version'
-	@echo '  make dist                  make binary and source packages'
-	@echo '  make dist-check            verify binary and source packages'
-	@echo '  make upload                upload to PyPI'
+	@echo '  make pypi-dist             make binary and source packages for PyPI'
+	@echo '  make pypi-dist-check       verify binary and source packages for PyPI'
+	@echo '  make conda-build           make binary and source packages for conda-forge'
 	@echo
 
 PYTHON = python
@@ -19,7 +19,7 @@ REPO_URL = {{ cookiecutter.git_url }}
 
 .PHONY: test
 test :
-	$(PYTHON) setup.py test
+	$(PYTHON) -m pytest -v --cov=hop.apps.{{ cookiecutter.app_name }}
 
 .PHONY: lint
 lint :
@@ -30,9 +30,7 @@ lint :
 
 .PHONY: format
 format :
-	# show diff via black
-	black tests --diff
-	black hop/apps/{{ cookiecutter.app_name }} --diff
+	autopep8 --recursive --in-place .
 
 .PHONY: doc
 doc :
@@ -43,14 +41,14 @@ changelog :
 	sed -i 's@## \[Unreleased]@## \[Unreleased]\n\n## \[$(VERSION)] - $(shell date +'%Y-%m-%d')@' CHANGELOG.md
 	sed -i 's@.*\[Unreleased]:.*@\[Unreleased]: $(REPO_URL)/compare/v$(VERSION)...HEAD\n[$(VERSION)]: $(REPO_URL)/releases/tag/v$(VERSION)@' CHANGELOG.md
 
-.PHONY: dist
-dist :
+.PHONY: pypi-dist
+pypi-dist :
 	$(PYTHON) setup.py sdist bdist_wheel
 
-.PHONY: dist-check
-dist-check:
+.PHONY: pypi-dist-check
+pypi-dist-check :
 	twine check dist/*
 
-.PHONY: upload
-upload:
-	twine upload dist/*
+.PHONY: conda-build
+conda-build :
+	conda build -c defaults -c conda-forge ./recipe

--- a/hop-{{cookiecutter.app_name}}-app/setup.cfg
+++ b/hop-{{cookiecutter.app_name}}-app/setup.cfg
@@ -1,10 +1,7 @@
-[aliases]
-test = pytest
-
-[tool:pytest]
-addopts = -v --cov=hop.apps.{{ cookiecutter.app_name }}
-
 [flake8]
+max-line-length = 110
+max-doc-length = 110
+ignore = E203, W503
 exclude =
     setup.py,
     hop/apps/{{ cookiecutter.app_name }}/_version.py,
@@ -15,3 +12,7 @@ exclude =
     doc/
 per-file-ignores =
 	__init__.py:F401
+
+[tool:pytest]
+log_cli = True
+log_cli_level = INFO

--- a/hop-{{cookiecutter.app_name}}-app/setup.py
+++ b/hop-{{cookiecutter.app_name}}-app/setup.py
@@ -11,8 +11,18 @@ install_requires = [
     "hop-client >= 0.0.5",
 ]
 extras_require = {
-    'dev': ['pytest', 'pytest-console-scripts', 'pytest-cov', 'flake8', 'flake8-black'],
-    'docs': ['sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-programoutput'],
+    'dev': [
+        'autopep8',
+        'flake8',
+        'pytest >= 5.0, < 5.4',
+        'pytest-console-scripts',
+        'pytest-cov',
+    ],
+    'docs': [
+        'sphinx',
+        'sphinx_rtd_theme',
+        'sphinxcontrib-programoutput',
+    ],
 }
 
 setup(
@@ -36,6 +46,7 @@ setup(
     python_requires = '>=3.6.*',
     install_requires = install_requires,
     extras_require = extras_require,
+    zip_safe = False,
 
     classifiers = [
         'Development Status :: 2 - Pre-Alpha',


### PR DESCRIPTION
This PR accomplishes a few tasks, mostly related to dev tooling and enumerated below:

*  Update Makefile with targets from adc-streaming. The main thing I wanted here is the use of autopep8 rather than black for code formatting, which is a bit less aggressive in its formatting and more configurable.
*  Update dev extras requirement for using autopep8.
*  Also added a zip_safe = False flag from adc-streaming, which tends to discourage making python eggs. Seems like a good option all around.
* Switch from `python setup.py test` back to `python -m pytest` since the former is deprecated and won't work with new versions of setuptools.

Note that this PR doesn't include any github actions CI stuff, which will take more thought to port in a way that's generalizable. Probably would have to make use of conditionals in the cookiecutter to make this a viable option.